### PR TITLE
Optimise images for svelte components

### DIFF
--- a/src/components/ArticleCard.svelte
+++ b/src/components/ArticleCard.svelte
@@ -3,19 +3,17 @@
   import type { UiCollectionEntry } from "@lib/types";
   export let articleEntry: UiCollectionEntry<"articles">;
 
-  const { collectionEntry: article, rendered } = articleEntry;
+  const { collectionEntry: article, rendered, image: coverImage } = articleEntry;
 </script>
 
 <li class="card">
   <a href={`/${article.slug}`} class="hidden-link" title={article.data.title}>
     <div class="image-container">
-      {#if article.data.coverImage}
-        <!-- Will migrate this back to an optimised image in the future -->
+      {#if coverImage}
         <img
-          src={article.data.coverImage.src}
+          src={coverImage.src}
           alt={article.data.title}
-          height={100}
-          loading="lazy"
+          {...coverImage.attributes}
         />
       {:else}
         <div class="placeholder">

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -1,6 +1,8 @@
+import type { GetImageResult } from "astro";
 import type { CollectionEntry, CollectionKey } from "astro:content";
 
 export interface UiCollectionEntry<T extends CollectionKey> {
     collectionEntry: CollectionEntry<T>,
-    rendered: Awaited<ReturnType<CollectionEntry<T>['render']>>
+    rendered: Awaited<ReturnType<CollectionEntry<T>['render']>>,
+    image: GetImageResult | null,
 }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,11 +2,13 @@
 import Articles from "@components/Articles.svelte";
 import Base from "@layouts/Base.astro";
 import { getArticles, sort } from "@lib/collections/articles";
+import { getImage } from "astro:assets";
 
 const okArticles = sort(await getArticles());
 const renderedArticles = await Promise.all(okArticles.map(async (article) => ({
   collectionEntry: article,
   rendered: await article.render(),
+  image: article.data.coverImage ? await getImage({src: article.data.coverImage, width: 500}) : null,
 })));
 ---
 


### PR DESCRIPTION
Closes #47 

I finally figured out how to use Astro's [getImage()](https://docs.astro.build/en/guides/images/#generating-images-with-getimage) function, which was far more difficult to figure out than you'd think.

All homepage images are now optimised webp's!