### PR TITLE
Slugify tags and title case user facing tags

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@astrojs/sitemap": "^3.0.3",
         "@astrojs/svelte": "^4.0.3",
         "@astrojs/ts-plugin": "^1.3.1",
+        "@sindresorhus/slugify": "^2.2.1",
         "astro": "^3.5.0",
         "astro-robots-txt": "^1.0.0",
         "clsx": "^2.0.0",
@@ -613,6 +614,57 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@sindresorhus/slugify": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/slugify/-/slugify-2.2.1.tgz",
+      "integrity": "sha512-MkngSCRZ8JdSOCHRaYd+D01XhvU3Hjy6MGl06zhOk614hp9EOAp5gIkBeQg7wtmxpitU6eAL4kdiRMcJa2dlrw==",
+      "dependencies": {
+        "@sindresorhus/transliterate": "^1.0.0",
+        "escape-string-regexp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@sindresorhus/slugify/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@sindresorhus/transliterate": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/transliterate/-/transliterate-1.6.0.tgz",
+      "integrity": "sha512-doH1gimEu3A46VX6aVxpHTeHrytJAG6HgdxntYnCFiIFHEM/ZGpG8KiZGBChchjQmG0XFIBL552kBTjVcMZXwQ==",
+      "dependencies": {
+        "escape-string-regexp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@sindresorhus/transliterate/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@sveltejs/vite-plugin-svelte": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@astrojs/sitemap": "^3.0.3",
     "@astrojs/svelte": "^4.0.3",
     "@astrojs/ts-plugin": "^1.3.1",
+    "@sindresorhus/slugify": "^2.2.1",
     "astro": "^3.5.0",
     "astro-robots-txt": "^1.0.0",
     "clsx": "^2.0.0",

--- a/src/components/ArticleCard.svelte
+++ b/src/components/ArticleCard.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import Metadata from "./Metadata.svelte";
   import type { UiCollectionEntry } from "@lib/types";
+  import { toTitleCase } from "@lib/utils";
+  import slugify from "@sindresorhus/slugify";
   export let articleEntry: UiCollectionEntry<"articles">;
 
   const { collectionEntry: article, rendered, coverImage } = articleEntry;
@@ -44,8 +46,12 @@
         <ul>
           {#each article.data.tags as tag}
             <li>
-              <a href={`/tags/${tag}`} class="no-visit" data-astro-prefetch>
-                {tag}
+              <a
+                href={`/tags/${slugify(tag)}`}
+                class="no-visit"
+                data-astro-prefetch
+              >
+                {toTitleCase(tag.replaceAll("-", " "))}
               </a>
             </li>
           {/each}

--- a/src/components/TagList.astro
+++ b/src/components/TagList.astro
@@ -1,4 +1,6 @@
 ---
+import { toTitleCase } from "@lib/utils";
+import slugify from "@sindresorhus/slugify";
 interface Props {
   tags?: string[];
 }
@@ -12,8 +14,8 @@ const { tags } = Astro.props;
       <h2>Tags</h2>
       <span class="innerlist">
         {tags.map((tag) => (
-          <a class="tag" href={`/tags/${tag.toLowerCase()}`}>
-            {tag.toLowerCase()}
+          <a class="tag" href={`/tags/${slugify(tag)}`}>
+            {toTitleCase(tag)}
           </a>
         ))}
       </span>

--- a/src/layouts/Article.astro
+++ b/src/layouts/Article.astro
@@ -17,7 +17,6 @@ interface Props {
 }
 
 const { title, date, tags, todo, coverImage, readingTime } = Astro.props.frontmatter || Astro.props;
-
 ---
 
 <Base title={title}>

--- a/src/lib/collections/articles.ts
+++ b/src/lib/collections/articles.ts
@@ -1,3 +1,6 @@
+import type { Tag } from "@lib/types";
+import { toTitleCase } from "@lib/utils";
+import slugify from "@sindresorhus/slugify";
 import { getCollection, type CollectionEntry } from "astro:content";
 
 export const sort = (
@@ -37,14 +40,16 @@ export const getArticlesWithoutOk = async (): Promise<
   return await getCollection("articles", ({ data }) => !data.ok);
 };
 
-export const getAllUniqueArticleTags = async () => {
+export const getAllUniqueArticleTags = async (): Promise<Tag[]> => {
   const articles = await getArticles();
 
-  const tags = articles
-    .flatMap((article) => article.data.tags)
-    .map((tag) => tag.toLowerCase());
+  const tags = articles.flatMap((article) => article.data.tags);
 
-  return [...new Set(tags)];
+  return [...new Set(tags)].map((tag) => ({
+    tag,
+    slug: slugify(tag),
+    pretty: toTitleCase(tag.replaceAll("-", " ")),
+  }));
 };
 
 export const getAllArticlesWithTag = async (

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -2,11 +2,17 @@ import type { GetImageResult } from "astro";
 import type { CollectionEntry, CollectionKey } from "astro:content";
 
 export interface UiCollectionEntry<T extends CollectionKey> {
-    collectionEntry: CollectionEntry<T>,
-    rendered: Awaited<ReturnType<CollectionEntry<T>['render']>>,
-    coverImage: {
-        webp: GetImageResult,
-        avif: GetImageResult,
-        original: NonNullable<CollectionEntry<T>['data']['coverImage']>
-    } | null
+  collectionEntry: CollectionEntry<T>;
+  rendered: Awaited<ReturnType<CollectionEntry<T>["render"]>>;
+  coverImage: {
+    webp: GetImageResult;
+    avif: GetImageResult;
+    original: NonNullable<CollectionEntry<T>["data"]["coverImage"]>;
+  } | null;
+}
+
+export interface Tag {
+  tag: string;
+  slug: string;
+  pretty: string;
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -9,3 +9,10 @@ export const debounce = <T extends (...args: Parameters<T>) => void>(
     timer = setTimeout(() => cb(...args), timeout);
   };
 };
+
+export const toTitleCase = (text: string) => {
+  return text
+    .split(" ")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+};

--- a/src/pages/tags.astro
+++ b/src/pages/tags.astro
@@ -3,10 +3,15 @@ import SearchIcon from "@components/Icons/SearchIcon.astro";
 import Base from "@layouts/Base.astro";
 import { getAllUniqueArticleTags } from "@lib/collections/articles";
 
-const uniqueTags = (await getAllUniqueArticleTags()).sort().map((tag) => ({
-  slug: tag,
-  tag: tag.replaceAll("-", " "),
-}));
+const uniqueTags = (await getAllUniqueArticleTags()).sort((a, b) => {
+  if (a.tag < b.tag) {
+    return -1;
+  } else if (a.tag > b.tag) {
+    return 1;
+  }
+
+  return 0;
+});
 ---
 
 <Base title="Tags">
@@ -26,10 +31,10 @@ const uniqueTags = (await getAllUniqueArticleTags()).sort().map((tag) => ({
       </div>
       <ul id="tag-list">
         {
-          uniqueTags.map(({ tag, slug }) => (
+          uniqueTags.map(({ slug, pretty }) => (
             <li>
               <a href={`/tags/${slug}/`} data-astro-prefetch>
-                {tag}
+                {pretty}
               </a>
             </li>
           ))

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -5,34 +5,36 @@ import {
   getAllUniqueArticleTags,
 } from "@lib/collections/articles";
 import { type CollectionEntry } from "astro:content";
+import type { Tag } from "@lib/types";
+
 export async function getStaticPaths() {
   const uniqueTags = await getAllUniqueArticleTags();
 
   return await Promise.all(
-    uniqueTags.map(async (tag) => ({
-      params: { tag },
+    uniqueTags.map(async ({ tag, slug }) => ({
+      params: { tag: slug },
       props: {
         articles: await getAllArticlesWithTag(tag),
+        tag,
       },
     }))
   );
 }
 
 interface Props {
-  tag: string;
+  tag: Tag;
   articles: CollectionEntry<"articles">[];
 }
 
-const { tag } = Astro.params;
-const { articles } = Astro.props;
+const { articles, tag: tagItem } = Astro.props;
 ---
 
-<Base title={`Articles with ${tag} tag`}>
+<Base title={`Articles with ${tagItem.pretty} tag`}>
   <main>
-    <h1>Tag: {tag}</h1>
+    <h1>Tag: {tagItem.pretty}</h1>
     <p>
-      A list of articles that have been tagged: <a href={`/tags/${tag}`}
-        >{tag}</a
+      A list of articles that have been tagged: <a
+        href={`/tags/${tagItem.slug}`}>{tagItem.pretty}</a
       >
     </p>
 
@@ -40,7 +42,9 @@ const { articles } = Astro.props;
       {
         articles.map((article) => (
           <li>
-            <a href={`/${article.slug}`} data-astro-prefetch>{article.data.title}</a>
+            <a href={`/${article.slug}`} data-astro-prefetch>
+              {article.data.title}
+            </a>
           </li>
         ))
       }


### PR DESCRIPTION
Closes #34 

- Tag urls are now slugified to avoid the url formatted spaces
- Tags are formatted with title case when displayed to the user
- Not sure how to go about ensuring that acronyms are fully capitalised, this feels like something that should be handled by people writing the articles rather than at a coding level